### PR TITLE
No validar los comuestos sin simplificar

### DIFF
--- a/Documentos/Información/Webgrafía.txt
+++ b/Documentos/Información/Webgrafía.txt
@@ -24,6 +24,7 @@ https://dle.rae.es/miscel%C3%A1neo#PNnyl9C
 https://www.mclibre.org/consultar/amaya/css/css-fuentes-web.html     
 https://developer.mozilla.org/es/docs/Web/CSS/outline-style
 https://developer.mozilla.org/es/docs/Web/HTML/Elemento/ul 
+https://developer.mozilla.org/es/docs/Web/JavaScript/Referencia/Objetos_globales/Math/floor
 
 #Añadir tipografía a css
 https://www.elblogdelseo.com/como-utilizar-cualquier-fuente-en-tu-web/

--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ Llevo mucho tiempo sin programar por que he tenido que hacer el proyecto de info
 
 - Me he dado cuenta de muchos errores que tengo en el juego
 
-- [ ] Los elementos si se puden se han de simplificar
+- [x] Los elementos si se puden se han de simplificar
 
 >~~Li<sub>2</sub>H<sub>2</sub>~~  NO → LiH Sí :happy:
 
@@ -330,6 +330,10 @@ Llevo mucho tiempo sin programar por que he tenido que hacer el proyecto de info
   >PH<sub>3</sub> 
   >AsH<sub>3</sub> 
   >SbH<sub>3</sub> 
+
+  **Jueves 18 Casa**
+  - He creado una rama Errores
+  - He solucionado uno de los Errores
 
 
 

--- a/Scripts/funcionCompuesto.js
+++ b/Scripts/funcionCompuesto.js
@@ -155,6 +155,52 @@ function comprobarSiPuedeGenerarCompuestos(primeraPalabra, prefijoPrimeraPalabra
         //Se asegura de que la suma de los dos prefijos es menor que al número total de prefijos
         if (prefijoPrimeraPalabra + prefijoSegundaPalabra <= numeroDePrefijos) {
 
+            //Asegurarse de que el compuesto esta simplificado al máximo
+            if (prefijoPrimeraPalabra > 1 && prefijoSegundaPalabra > 1) {
+
+                //Almacena el valor maximo del número de oxidación
+
+                var max, min;
+
+                //Almacena el resultado de la división de max/min
+
+                let division;
+
+                //Si el mayor es primero
+                if (prefijoPrimeraPalabra > prefijoSegundaPalabra) {
+
+                    max = prefijoPrimeraPalabra;
+
+                    min = prefijoSegundaPalabra;
+
+                }
+                //sino
+                else {
+                    max = prefijoSegundaPalabra;
+
+                    min = prefijoPrimeraPalabra;
+
+                }
+
+                //Divide el máximo entre el mínimo
+                division = max / min;
+
+                console.log("funciona correctamente");
+
+                console.info(division);
+
+                //Si el valor de la division es igual a la prate entera de la división
+                //Es decir comprueba si es entero o decimal
+
+                if (division === Math.floor(division)/*Math.floor() saca la parte entera de la coma*/) {
+
+                    return false;
+
+                }
+
+
+            }
+
             //Se asegura de que los compuestos estan
             if (comprobarSiEstanLosCompuestos(primeraPalabra, prefijoPrimeraPalabra, mapa) && comprobarSiEstanLosCompuestos(segundaPalabra, prefijoSegundaPalabra, mapa)) {
 


### PR DESCRIPTION
He hecho que cuando un compuesto se pueda simplificar se haya de simplificar.

También he aprendido a utilizar el 
```javascript
> //x es cualquier número
>Math.floor(x);
```