### PR TITLE
Añadir el nitrógeno a las sustancias simples

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,3 +558,4 @@ Javier Ribal del Río 3ºB Nº21 Informática
 **Lunes 29**
 
 - He solucionado el error que ocurria al robar 1 carta
+- He solucionado el error de que el nitrógeno no salia en las substancias simples

--- a/src/SustanciasSimples.js
+++ b/src/SustanciasSimples.js
@@ -23,8 +23,8 @@ function identificarSustanciasSimples(textoUsuario, elementosDisponibles, map) {
 
             //Se repite una vez por cada 
             for (var j = 0; j < elementosDisponibles[i].v.length; j++) {
-
-                if (elementosDisponibles[i].v[j] === -1 || elementosDisponibles[i].z === 8) {
+                /*Los que tienen valencia -a*/          /*El oxígeno */                       /*El nitrógeno*/
+                if (elementosDisponibles[i].v[j] === -1 || elementosDisponibles[i].z === 8 || elementosDisponibles[i].z === 7) {
 
                     //Se repite una vez por cada elemento del map
                     map.forEach(function (valor, key) {


### PR DESCRIPTION
Añadir el nitrógeno (N) a las sustancias simples y aprovechar para subsaknar el error que había desencadenado quitarle la valencia -1 al oxígeno (O).